### PR TITLE
Fix startup issue with missing dotenv module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "student-chatbot",
+  "version": "1.0.0",
+  "main": "server.js",
+  "type": "commonjs",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.1.4",
+    "express": "^4.18.2",
+    "openai": "^4.44.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,4 +1,8 @@
-require('dotenv').config();
+try {
+  require('dotenv').config();
+} catch (err) {
+  console.warn('⚠️  dotenv not installed, skipping .env loading');
+}
 const express = require('express');
 const cors = require('cors');
 const fs = require('fs');


### PR DESCRIPTION
## Summary
- handle missing `dotenv` gracefully so server can start without the package
- add `package.json` documenting required dependencies

## Testing
- `node -c server.js`
- `npm install` *(fails: 403 Forbidden because network access is disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68651cdaa3848325b347ea4163063fed